### PR TITLE
Fix missing check for CentOS(low version)

### DIFF
--- a/arch/common.bash
+++ b/arch/common.bash
@@ -59,6 +59,8 @@ function os_name()
         cat /etc/os-release | egrep "^ID=" | sed "s/ID=//g"
     elif [ -f /etc/lsb-release ]; then
         cat /etc/lsb-release | egrep "^DISTRIB_ID=" | sed "s/DISTRIB_ID=//g"
+    elif [ -f /etc/centos-release ]; then
+        cat /etc/centos-release | awk '{print $1}' | tr "[:upper:]" "[:lower:]"
     else
         echo "unknown"
     fi


### PR DESCRIPTION
centos 6.8 에서는 /etc/lsb-relase 가 없습니도.
환경상의 차이인지 .. 모르겠심도.

[soonsebii@rabbitmq oh-my-fzf]$ ls /etc/*release -al
-rw-r--r--. 1 root root 27 2016-05-19 04:47 /etc/centos-release
lrwxrwxrwx. 1 root root 14 2016-10-10 18:35 /etc/redhat-release -> centos-release
lrwxrwxrwx. 1 root root 14 2016-10-10 18:35 /etc/system-release -> centos-release
